### PR TITLE
 Fix bug for ^Boolean type hint

### DIFF
--- a/src/defsql/core.clj
+++ b/src/defsql/core.clj
@@ -101,7 +101,7 @@
 
 (defn set-nullable-boolean*
   [^java.sql.PreparedStatement ps ^Integer idx ^Boolean b]
-  (if b
+  (if-not (nil? b)
     (.setBoolean ps idx b)
     (.setNull ps idx java.sql.Types/BOOLEAN)))
 


### PR DESCRIPTION
Passing false for a ^Boolean type hint resulted in nil instead of a false boolean instance, which causes issues on non-nullable columns.
